### PR TITLE
feat(algorithm): add CLD3 and CLD2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ A benchmark of off-the-shelf models that detects language in text - Contribution
 - Collaborators can serve as peer reviewers.
 
 ### Results
-| algorithm    | mean   | max    | min    | median | mem       | accuracy |
-| ------------ | ------ | ------ | ------ | ------ | --------- | -------- |
-| Langid       | 0.0005 | 0.0145 | 0.0001 | 0.0004 | 34.46 mb  | 0.9543   |
-| Fasttext_ftz | 0.0002 | 0.0014 | 0.0000 | 0.0001 | 0.71 mb   | 0.9673   |
-| Fasttext_bin | 0.0001 | 0.0031 | 0.0000 | 0.0001 | 131.11 mb | 0.9751   |
-
+| algorithm    | mean   | max    | min    | median | mem         | accuracy |
+| ------------ | ------ | ------ | ------ | ------ | ----------- | -------- |
+| Langid       | 0.0005 | 0.0145 | 0.0001 | 0.0004 | 34.46 mb    | 0.9543   |
+| Fasttext_ftz | 0.0002 | 0.0014 | 0.0000 | 0.0001 | 0.71 mb     | 0.9673   |
+| Fasttext_bin | 0.0001 | 0.0031 | 0.0000 | 0.0001 | 131.11 mb   | 0.9751   |
+| CLD3         | 0.0004 | 0.0021 | 0.0000 | 0.0003 | 0.000053 mb | 0.9557   |
+| CLD2         | 0.0000 | 0.0002 | 0.0000 | 0.0000 | 0.0 mb      | 0.9308   |

--- a/benchmark_cld2.py
+++ b/benchmark_cld2.py
@@ -1,0 +1,73 @@
+import psutil
+import os
+import pycld2 as cld2
+import regex
+import time
+import math
+import numpy as np
+import sys
+import pandas as pd 
+from language_dictionary import lang_dict
+from object_size import getsize
+from tqdm.auto import tqdm
+pd.set_option("max_colwidth", None)
+tqdm.pandas()
+from typing import List
+
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s | %(levelname)s | %(message)s')
+
+
+class BenchmarkCLD2():
+
+      def __init__(self):
+           """ dummy run to load the model and get memory usage """
+           p = psutil.Process(os.getpid())
+           mem_before = p.memory_info().rss
+           cld2.detect('Hello World')
+           mem_after = p.memory_info().rss
+           self.mem_usage = mem_after - mem_before
+           logger.info('Default model for CLD2 loaded ...')
+
+      def _detect_language(self, row):
+              """Detects language for the given text"""
+              text = row['Text']
+              gt = row['language']
+              start = time.time()
+              pred = cld2.detect(text)[2][0][1]
+              end = time.time() - start
+              match = gt == pred      
+              return pd.Series([pred, end, match])
+
+      def __call__(self) -> List[pd.DataFrame]:
+          """ detects language for all the texts and calculates benchmark """
+          logger.info('Benchmark for CLD2 started ...')
+          MB = 1024 * 1024
+          df = pd.read_csv("data/dataset.csv")  
+          df['language'] = df['language'].apply(lambda x:lang_dict[x])
+          # https://github.com/mikemccand/chromium-compact-language-detector/issues/22#issuecomment-707999784
+          RE_BAD_CHARS = regex.compile(r"\p{Cc}|\p{Cs}")
+          df['Text'] = df['Text'].apply(lambda x:RE_BAD_CHARS.sub("", x))
+          df[['pred_lang', 'time_taken', 'ismatch']] = df.progress_apply(self._detect_language ,axis=1)
+          time_taken = df["time_taken"].to_list()
+          correct_predictions = df[df['ismatch'] == True].shape[0]
+          total_predictions = df.shape[0]
+
+          d = {"algorithm": "CLD2",
+               "mean": np.mean(time_taken),
+               "max" : np.max(time_taken),
+               "min" : np.min(time_taken),
+               "median" : np.median(time_taken),
+               "mem": str(round(self.mem_usage/ MB,2)) + " mb",
+               "accuracy":correct_predictions/ total_predictions
+               }
+          
+          df.to_csv("data/predictions_cld2.csv", index = False)
+          summary_df = pd.DataFrame([d]) 
+
+          logger.info('Benchmark for CLD2 ended ...')
+          logger.info('See predictions_cld2.csv files...')
+
+          return [summary_df]

--- a/benchmark_cld3.py
+++ b/benchmark_cld3.py
@@ -1,0 +1,71 @@
+import psutil
+import os
+import gcld3
+import time
+import math
+import numpy as np
+import sys
+import pandas as pd 
+from language_dictionary import lang_dict
+from object_size import getsize
+from tqdm.auto import tqdm
+pd.set_option("max_colwidth", None)
+tqdm.pandas()
+from typing import List
+
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s | %(levelname)s | %(message)s')
+
+
+class BenchmarkCLD3():
+
+      def __init__(self):
+           """ dummy run to load the model and get memory usage """
+           p = psutil.Process(os.getpid())
+           mem_before = p.memory_info().rss
+           self.model = gcld3.NNetLanguageIdentifier(min_num_bytes=0, max_num_bytes=1000)
+           self.model.FindLanguage(text="Hello World")
+           mem_after = p.memory_info().rss
+           mem_model = getsize(self.model)
+           self.mem_usage = (mem_after - mem_before) + mem_model
+           logger.info('Default model for CLD3 loaded ...')
+
+      def _detect_language(self, row):
+              """Detects language for the given text"""
+              text = row['Text']
+              gt = row['language']
+              start = time.time()
+              pred = self.model.FindLanguage(text=text).language
+              end = time.time() - start
+              match = gt == pred      
+              return pd.Series([pred, end, match])
+
+      def __call__(self) -> List[pd.DataFrame]:
+          """ detects language for all the texts and calculates benchmark """
+          logger.info('Benchmark for CLD3 started ...')
+          MB = 1024 * 1024
+          df = pd.read_csv("data/dataset.csv")  
+          df['language'] = df['language'].apply(lambda x:lang_dict[x])
+          df[['pred_lang', 'time_taken', 'ismatch']] = df.progress_apply(self._detect_language ,axis=1)
+          time_taken = df["time_taken"].to_list()
+          correct_predictions = df[df['ismatch'] == True].shape[0]
+          total_predictions = df.shape[0]
+
+          d = {"algorithm": "CLD3",
+               "mean": np.mean(time_taken),
+               "max" : np.max(time_taken),
+               "min" : np.min(time_taken),
+               "median" : np.median(time_taken),
+               "mem": str(format(self.mem_usage/ MB,'f')) + " mb",
+               "accuracy":correct_predictions/ total_predictions
+               }
+          
+          df.to_csv("data/predictions_cld3.csv", index = False)
+          summary_df = pd.DataFrame([d]) 
+
+          logger.info('Benchmark for CLD3 ended ...')
+          logger.info('See predictions_cld3.csv files...')
+
+          return [summary_df]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 fasttext
+gcld3
 mdtable
 pandas
+psutil
+pycld2
 py3langid
+regex
 requests
 tqdm

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -22,6 +22,8 @@ logger.addHandler(stdout_handler)
 
 from benchmark_langid import BenchmarkLangid
 from benchmark_fasttext import BenchmarkFasttext
+from benchmark_cld3 import BenchmarkCLD3
+from benchmark_cld2 import BenchmarkCLD2
 ### ADD YOUR IMPLEMENTATIONS HERE ###
 
 
@@ -52,6 +54,12 @@ if __name__ == '__main__':
     if "Fasttext" in algorithm_list or "*" in algorithm_list:
         benchmark_fasttext = BenchmarkFasttext()
         summary_df_list.extend(benchmark_fasttext())
+    if "CLD3" in algorithm_list or "*" in algorithm_list:
+        benchmark_cld3 = BenchmarkCLD3()
+        summary_df_list.extend(benchmark_cld3())
+    if "CLD2" in algorithm_list or "*" in algorithm_list:
+        benchmark_cld2 = BenchmarkCLD2()
+        summary_df_list.extend(benchmark_cld2())
 
     summary_df = pd.concat(summary_df_list)
     summary_df.to_csv("data/benchmark_results.csv", index=False, float_format='%.4f')        


### PR DESCRIPTION
Added CLD3 and CLD 2 algorithm. CLD3 works in both Python 3.7 and 3.8. CLD 2 works in Python 3.7 but not in 3.8

To test benchmarks for CLD3 and CLD2:

- Run Docker container for Python 3.7 while mounting cloned repo from pull request:
docker run -it --network host --ipc=host --name langid_benchmark -v /home/user/workspace/langid-benchmark:/home -w /home python:3.7-slim-buster bash

- Install Protobuf
apt-get install -y --no-install-recommends g++ protobuf-compiler libprotobuf-dev

- Install pip packages
python -m pip install --no-cache-dir -r requirements.txt

- Run benchmark script
python run_benchmark.py -al CLD3 CLD2